### PR TITLE
feat: add astroportal theme stylesheet directory

### DIFF
--- a/app/assets/stylesheets/themes/astroportal/main.scss
+++ b/app/assets/stylesheets/themes/astroportal/main.scss
@@ -1,0 +1,6 @@
+$color-primary: var(--primary-color);
+$color-secondary: #EFFFEF;
+$color-links: var(--primary-color);
+$color-warning: #ffc107;
+@import "../lirmm/main";
+@import "search";

--- a/app/assets/stylesheets/themes/astroportal/search.scss
+++ b/app/assets/stylesheets/themes/astroportal/search.scss
@@ -1,0 +1,3 @@
+.search_result_links a {
+  color: $color-primary !important;
+}


### PR DESCRIPTION
## Problem

The `astroportal` theme was added to `theme-variables.scss.erb` (commit 68c0477) with only the color variables, but **no `app/assets/stylesheets/themes/astroportal/` directory** was created.

`application.css.scss.erb` only imports the theme entrypoint when its directory exists.

Relates to ontoportal-astro/project-management#35.